### PR TITLE
Update the target link of MAT download in the translations page

### DIFF
--- a/docs/translations.md
+++ b/docs/translations.md
@@ -4,7 +4,7 @@ To help translate, follow these instructions.
 
 ## Add localization resources
 
- 1. Ensure you have Visual Studio 2022 for windows and the [Multilingual App Toolkit extension](https://marketplace.visualstudio.com/items?itemName=MultilingualAppToolkit.MultilingualAppToolkit-18308).
+ 1. Ensure you have Visual Studio 2022 for windows and the [Multilingual App Toolkit extension](https://marketplace.visualstudio.com/items?itemName=dts-publisher.mat2022).
  2. Fork and clone this repository.
  3. Open in Visual Studio 2022.
  4. Select Multilingual App Toolkit > Add translation language.


### PR DESCRIPTION
Fix the target link of the Multilingual App Toolkit extension from the deprecated page to the new one

### Description
The link to download MAT in the [translation document](https://github.com/FluentHub/FluentHub/blob/main/docs/translations.md) points to an old page. Now, the new MAT for VS 2022 has its own download page.
![image](https://github.com/FluentHub/FluentHub/assets/36733265/8db0560a-dd23-4b3c-a73f-94e7cf55bf75)

### Motivation and Context

### Change Area

- [x] Documentation
- [ ] CI
- [ ] Code
- [ ] Design

### PR Checklit

- [ ] Were these changes approved in an discussion by the project maintainers to prevent from extra work?
- [x] Did you build the app and test your changes?
- [x] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file after seeing if the string wasn't being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [ ] Are there any other steps that were used to validate these changes?
   1. 
   2. 

### Screenshots
